### PR TITLE
Add a TypeConverter for wrapper types

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ ColorName deserializedColor = JsonSerializer.Deserialize<ColorName>(json);
 Console.WriteLine(deserializedColor); // "green"
 ```
 
+#### TypeConverter Support
+
+A `TypeConverter` is added to the wrapper that can create the wrapper to and from its wrapped type. Conversion from `string` is also supported via `TypeConverter` passthrough.
+
+This allows wrappers to be used as their wrapped type in many scenarios, like `IConfigurationBinder` binding or ASP.NET Core query parameter binding.
+
 #### Nested Wrappers
 
 Wrappers inside other classes are supported, as long as each containing class is marked `partial`:
@@ -255,7 +261,7 @@ public static KilometersExtensions
 }
 ```
 
-## Benchmarks (v1.0.1)
+## Benchmarks
 
 ### ToString Passthrough
 
@@ -263,22 +269,22 @@ public static KilometersExtensions
 
 | Method            | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |------------------ |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
-| WrapperToString   | 47.77 ns | 0.920 ns | 0.860 ns |  0.95 |    0.03 | 0.0172 |     288 B |        1.00 |
-| PrimitiveToString | 50.30 ns | 1.041 ns | 1.157 ns |  1.00 |    0.03 | 0.0172 |     288 B |        1.00 |
+| WrapperToString   | 47.31 ns | 0.730 ns | 0.683 ns |  1.04 |    0.02 | 0.0172 |     288 B |        1.00 |
+| PrimitiveToString | 45.67 ns | 0.694 ns | 0.615 ns |  1.00 |    0.02 | 0.0172 |     288 B |        1.00 |
 
 #### Wrapped `double`
 
-| Method            | Mean     | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
-|------------------ |---------:|---------:|---------:|------:|-------:|----------:|------------:|
-| WrapperToString   | 38.56 ns | 0.317 ns | 0.281 ns |  0.97 | 0.0014 |      24 B |        1.00 |
-| PrimitiveToString | 39.64 ns | 0.387 ns | 0.362 ns |  1.00 | 0.0014 |      24 B |        1.00 |
+| Method            | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|------------------ |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| WrapperToString   | 39.27 ns | 0.647 ns | 0.605 ns |  1.00 |    0.02 | 0.0014 |      24 B |        1.00 |
+| PrimitiveToString | 39.19 ns | 0.509 ns | 0.425 ns |  1.00 |    0.01 | 0.0014 |      24 B |        1.00 |
 
 #### Wrapped `string`
 
 | Method            | Mean      | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
 |------------------ |----------:|----------:|----------:|------:|--------:|----------:|------------:|
-| WrapperToString   | 0.0828 ns | 0.0243 ns | 0.0316 ns |  0.13 |    0.05 |         - |          NA |
-| PrimitiveToString | 0.6638 ns | 0.0507 ns | 0.0474 ns |  1.00 |    0.10 |         - |          NA |
+| WrapperToString   | 0.1560 ns | 0.0190 ns | 0.0177 ns |  0.32 |    0.04 |         - |          NA |
+| PrimitiveToString | 0.4907 ns | 0.0186 ns | 0.0165 ns |  1.00 |    0.05 |         - |          NA |
 
 ### System.Text.Json Round-Trip
 
@@ -288,22 +294,45 @@ Non-built-in wrapped types incur a penalty.
 
 | Method                 | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |----------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| WrapperRoundTripJson   | 434.8 ns | 8.37 ns | 9.96 ns |  1.79 |    0.05 | 0.0057 |      96 B |        1.00 |
-| PrimitiveRoundTripJson | 242.5 ns | 4.45 ns | 5.12 ns |  1.00 |    0.03 | 0.0057 |      96 B |        1.00 |
+| WrapperRoundTripJson   | 410.1 ns | 5.10 ns | 4.52 ns |  1.82 |    0.06 | 0.0057 |      96 B |        1.00 |
+| PrimitiveRoundTripJson | 225.4 ns | 4.00 ns | 7.01 ns |  1.00 |    0.04 | 0.0057 |      96 B |        1.00 |
 
 #### Wrapped `double`
 
 | Method                 | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |----------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| WrapperRoundTripJson   | 161.3 ns | 1.73 ns | 1.61 ns |  1.03 |    0.02 | 0.0019 |      32 B |        1.00 |
-| PrimitiveRoundTripJson | 156.2 ns | 2.00 ns | 1.87 ns |  1.00 |    0.02 | 0.0019 |      32 B |        1.00 |
+| WrapperRoundTripJson   | 160.5 ns | 2.49 ns | 2.33 ns |  1.04 |    0.02 | 0.0019 |      32 B |        1.00 |
+| PrimitiveRoundTripJson | 154.3 ns | 1.26 ns | 1.18 ns |  1.00 |    0.01 | 0.0019 |      32 B |        1.00 |
 
 #### Wrapped `string`
 
 | Method                 | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |----------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| WrapperRoundTripJson   | 128.7 ns | 1.18 ns | 1.04 ns |  0.96 |    0.01 | 0.0043 |      72 B |        1.00 |
-| PrimitiveRoundTripJson | 134.6 ns | 1.99 ns | 1.86 ns |  1.00 |    0.02 | 0.0043 |      72 B |        1.00 |
+| WrapperRoundTripJson   | 136.1 ns | 2.08 ns | 1.95 ns |  1.00 |    0.02 | 0.0043 |      72 B |        1.00 |
+| PrimitiveRoundTripJson | 136.3 ns | 1.49 ns | 1.32 ns |  1.00 |    0.01 | 0.0043 |      72 B |        1.00 |
+
+### TypeConverter Round-Trip (to/from `string`)
+
+#### Wrapped `struct`
+
+| Method                   | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
+|------------------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
+| WrapperRoundTripString   | 248.5 ns | 3.40 ns | 3.01 ns |  1.05 | 0.0086 |     144 B |        1.20 |
+| PrimitiveRoundTripString | 235.9 ns | 1.84 ns | 1.54 ns |  1.00 | 0.0072 |     120 B |        1.00 |
+
+#### Wrapped `double`
+
+| Method                   | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|------------------------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| WrapperRoundTripString   | 76.56 ns | 1.262 ns | 1.054 ns |  1.03 |    0.02 | 0.0057 |      96 B |        1.33 |
+| PrimitiveRoundTripString | 74.03 ns | 0.826 ns | 0.773 ns |  1.00 |    0.01 | 0.0043 |      72 B |        1.00 |
+
+#### Wrapped `string`
+
+| Method                   | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|------------------------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| WrapperRoundTripString   | 14.56 ns | 0.169 ns | 0.149 ns |  1.27 |    0.02 | 0.0029 |      48 B |        2.00 |
+| PrimitiveRoundTripString | 11.43 ns | 0.175 ns | 0.155 ns |  1.00 |    0.02 | 0.0014 |      24 B |        1.00 |
 
 ### Source Generator
 

--- a/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/PositiveCoordinate.cs
+++ b/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/PositiveCoordinate.cs
@@ -1,6 +1,35 @@
-﻿namespace Yoyoyopo5.ValueWrapper.Benchmarks;
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
 
+namespace Yoyoyopo5.ValueWrapper.Benchmarks;
+
+[TypeConverter(typeof(CoordinateTypeConverter))]
 public readonly record struct Coordinate(int X, int Y);
+
+public class CoordinateTypeConverter : TypeConverter
+{
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+        => sourceType == typeof(string)
+        || base.CanConvertFrom(context, sourceType);
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+        => value switch
+        {
+            string stringValue => JsonSerializer.Deserialize<Coordinate>(stringValue),
+            _ => base.ConvertFrom(context, culture, value)
+        };
+
+    public override bool CanConvertTo(ITypeDescriptorContext? context, [NotNullWhen(true)] Type? destinationType)
+        => destinationType == typeof(string)
+        || base.CanConvertTo(context, destinationType);
+    public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
+        => value switch
+        {
+            Coordinate coordinate when destinationType == typeof(string) => JsonSerializer.Serialize(coordinate),
+            _ => base.ConvertTo(context, culture, value, destinationType)
+        };
+}
 
 [Wrapper<Coordinate>]
 public readonly partial record struct PositiveCoordinate(Coordinate Value);

--- a/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/Program.cs
+++ b/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/Program.cs
@@ -1,8 +1,11 @@
-﻿using Yoyoyopo5.ValueWrapper.Benchmarks;
+﻿using System.ComponentModel;
+using Yoyoyopo5.ValueWrapper.Benchmarks;
 using Yoyoyopo5.ValueWrapper.Benchmarks.Create;
 using Yoyoyopo5.ValueWrapper.Benchmarks.Json;
 using Yoyoyopo5.ValueWrapper.Benchmarks.ToString;
+using Yoyoyopo5.ValueWrapper.Benchmarks.TypeConv;
 
 //JsonBenchmarks<ColorName, string>.Run();
-CreateBenchmarks<ColorName, string>.Run();
+//CreateBenchmarks<ColorName, string>.Run();
 //ToStringBenchmarks<ColorName, string>.Run();
+TypeConverterBenchmarks<ColorName, string>.Run();

--- a/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/TypeConv/CoordinateTypeConverterBenchmarks.cs
+++ b/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/TypeConv/CoordinateTypeConverterBenchmarks.cs
@@ -1,0 +1,7 @@
+﻿namespace Yoyoyopo5.ValueWrapper.Benchmarks.TypeConv;
+
+public class CoordinateTypeConverterBenchmarks : TypeConverterBenchmarks<PositiveCoordinate, Coordinate>
+{
+    protected override Coordinate Primitive => new(2,3);
+    protected override PositiveCoordinate Wrapper => new(new(2,3));
+}

--- a/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/TypeConv/DoubleTypeConverterBenchmarks.cs
+++ b/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/TypeConv/DoubleTypeConverterBenchmarks.cs
@@ -1,0 +1,7 @@
+﻿namespace Yoyoyopo5.ValueWrapper.Benchmarks.TypeConv;
+
+public class DoubleTypeConverterBenchmarks : TypeConverterBenchmarks<Meters, double>
+{
+    protected override double Primitive => 3.0;
+    protected override Meters Wrapper => new(3.0);
+}

--- a/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/TypeConv/StringTypeConverterBenchmarks.cs
+++ b/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/TypeConv/StringTypeConverterBenchmarks.cs
@@ -1,0 +1,7 @@
+﻿namespace Yoyoyopo5.ValueWrapper.Benchmarks.TypeConv;
+
+public class StringTypeConverterBenchmarks : TypeConverterBenchmarks<ColorName, string>
+{
+    protected override string Primitive => "green";
+    protected override ColorName Wrapper => new("green");
+}

--- a/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/TypeConv/TypeConverterBenchmarks.cs
+++ b/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/TypeConv/TypeConverterBenchmarks.cs
@@ -1,0 +1,40 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using System.ComponentModel;
+
+namespace Yoyoyopo5.ValueWrapper.Benchmarks.TypeConv;
+
+[MemoryDiagnoser]
+public abstract class TypeConverterBenchmarks<TWrapper, TWrapped>
+    where TWrapper : IWrapValue<TWrapped, TWrapper>
+{
+    public static IReadOnlyList<Summary> Run()
+    {
+        List<Summary> summaries = [];
+        summaries.Add(BenchmarkRunner.Run<CoordinateTypeConverterBenchmarks>());
+        summaries.Add(BenchmarkRunner.Run<DoubleTypeConverterBenchmarks>());
+        summaries.Add(BenchmarkRunner.Run<StringTypeConverterBenchmarks>());
+        return summaries;
+    }
+
+    protected abstract TWrapped Primitive { get; }
+    protected abstract TWrapper Wrapper { get; }
+
+    private static readonly TypeConverter WrappedConverter = TypeDescriptor.GetConverter(typeof(TWrapped));
+    private static readonly TypeConverter WrapperConverter = TypeDescriptor.GetConverter(typeof(TWrapper));
+
+    [Benchmark]
+    public void WrapperRoundTripString()
+    {
+        string s = WrapperConverter.ConvertToInvariantString(Wrapper)!;
+        WrapperConverter.ConvertFromInvariantString(s);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void PrimitiveRoundTripString()
+    {
+        string s = WrappedConverter.ConvertToInvariantString(Primitive)!;
+        WrapperConverter.ConvertFromInvariantString(s);
+    }
+}

--- a/src/Yoyoyopo5.ValueWrapper.Analyzer/ValueWrapperDiagnostics.cs
+++ b/src/Yoyoyopo5.ValueWrapper.Analyzer/ValueWrapperDiagnostics.cs
@@ -25,7 +25,7 @@ internal static class ValueWrapperDiagnostics
     public static readonly DiagnosticDescriptor JsonConstructionMethodMissingWarning = new(
         id: "VWG0003",
         title: "Wrapper type is not constructable",
-        messageFormat: "To enable wrapper Json deserialization, '{0}' must have: " +
+        messageFormat: "To enable wrapper JSON and Type conversion, '{0}' must have: " +
         "(1) a public constructor taking a single argument of the wrapped type, " +
         "(2) a publicly initializable Value property of the wrapped type, or " +
         "(3) a static Create method taking a single argument of the wrapped type and returning an instance of {0}",

--- a/src/Yoyoyopo5.ValueWrapper.Generator/GeneratorAttributeSyntaxContextExtensions.cs
+++ b/src/Yoyoyopo5.ValueWrapper.Generator/GeneratorAttributeSyntaxContextExtensions.cs
@@ -20,7 +20,11 @@ internal static class GeneratorAttributeSyntaxContextExtensions
         ct.ThrowIfCancellationRequested();
         return wrapperTypeSymbol.ToValueWrapperDefinition(
             wrappedTypeSymbol,
-            context.SemanticModel.Compilation.GetTypeByMetadataName(ValueWrapperConstants.JSON_CONVERTER_ATTRIBUTE_TYPE_NAME),
+            new AssemblySymbolContext()
+            {
+                JsonConverterAttribute = context.SemanticModel.Compilation.GetTypeByMetadataName(ValueWrapperConstants.JSON_CONVERTER_ATTRIBUTE_TYPE_NAME),
+                TypeConverterAttribute = context.SemanticModel.Compilation.GetTypeByMetadataName(ValueWrapperConstants.TYPE_CONVERTER_ATTRIBUTE_TYPE_NAME)
+            },
             ct
             );
     }

--- a/src/Yoyoyopo5.ValueWrapper.Generator/INamedTypeSymbolExtensions.cs
+++ b/src/Yoyoyopo5.ValueWrapper.Generator/INamedTypeSymbolExtensions.cs
@@ -6,12 +6,18 @@ using Yoyoyopo5.ValueWrapper.Roslyn.Shared;
 
 namespace Yoyoyopo5.ValueWrapper.Generator;
 
+internal record AssemblySymbolContext
+{
+    public INamedTypeSymbol? JsonConverterAttribute { get; init; }
+    public INamedTypeSymbol? TypeConverterAttribute { get; init; }
+}
+
 internal static class INamedTypeSymbolExtensions
 {
     public static ValueWrapperDefinition? ToValueWrapperDefinition(
         this INamedTypeSymbol typeSymbol,
         INamedTypeSymbol wrappedTypeSymbol,
-        INamedTypeSymbol? jsonConverterAttributeSymbol,
+        AssemblySymbolContext symbolContext,
         CancellationToken ct)
         => new()
         {
@@ -27,7 +33,8 @@ internal static class INamedTypeSymbolExtensions
             WrapperValueProperty = ValuePropertyInfo.FromTypeSymbol(typeSymbol, wrappedTypeSymbol, ct),
             ImplicitOperator = ImplicitOperatorInfo.FromTypeSymbol(typeSymbol, wrappedTypeSymbol, ct),
             ToStringOverride = ToStringOverrideInfo.FromTypeSymbol(typeSymbol, ct),
-            HasJsonConverterAttribute = typeSymbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, jsonConverterAttributeSymbol)),
+            HasJsonConverterAttribute = typeSymbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, symbolContext.JsonConverterAttribute)),
+            HasTypeConverterAttribute = typeSymbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, symbolContext.TypeConverterAttribute)),
             StaticCreateMethod = StaticCreateMethodInfo.FromTypeSymbol(typeSymbol, wrappedTypeSymbol, ct),
             HasEmptyConstructor = typeSymbol.InstanceConstructors.Any(c => c.Parameters.IsEmpty),
             HasOtherRequiredProperties = typeSymbol.GetMembers().OfType<IPropertySymbol>().Where(p => p.IsRequired).Any(p => p.Name != "Value")

--- a/src/Yoyoyopo5.ValueWrapper.Generator/TemplateExtensions.cs
+++ b/src/Yoyoyopo5.ValueWrapper.Generator/TemplateExtensions.cs
@@ -19,6 +19,7 @@ internal static class TemplateExtensions
                 WrappedTypeName = wrapper.WrappedType.FullyQualifiedName,
                 PartialDefinition = wrapper.PartialDeclaration,
                 JsonConverterType = wrapper.HasJsonConverterAttribute ? null : ValueWrapperConstants.WRAPPER_JSON_CONVERTER_NAME.Replace("`2", $"<{wrapper.Name}, {wrapper.WrappedType.FullyQualifiedName}>"),
+                TypeConverterType = wrapper.HasTypeConverterAttribute ? null : ValueWrapperConstants.WRAPPER_TYPE_CONVERTER_NAME.Replace("`2", $"<{wrapper.Name}, {wrapper.WrappedType.FullyQualifiedName}>"),
                 wrapper.ShouldAddValueProperty,
                 ShouldAddImplicitOperator = wrapper.ImplicitOperator is null,
                 ShouldAddToStringOverride = wrapper.ToStringOverride is null,

--- a/src/Yoyoyopo5.ValueWrapper.Generator/ValueWrapper.scriban
+++ b/src/Yoyoyopo5.ValueWrapper.Generator/ValueWrapper.scriban
@@ -23,6 +23,9 @@
 {{- if json_converter_type && json_create_expression ~}}
 [global::System.Text.Json.Serialization.JsonConverter(typeof({{ json_converter_type }}))]
 {{ end ~}}
+{{- if type_converter_type && json_create_expression ~}}
+[global::System.ComponentModel.TypeConverter(typeof({{ type_converter_type }}))]
+{{ end ~}}
 {{ partial_definition }}
 {{- if wrapper_interface && json_create_expression }}
     : {{ wrapper_interface }}

--- a/src/Yoyoyopo5.ValueWrapper.Generator/ValueWrapperDefinition.cs
+++ b/src/Yoyoyopo5.ValueWrapper.Generator/ValueWrapperDefinition.cs
@@ -15,6 +15,7 @@ internal record ValueWrapperDefinition
     public required bool IsPartial { get; init; }
     public required bool IsRecord { get; init; }
     public required bool HasJsonConverterAttribute { get; init; }
+    public required bool HasTypeConverterAttribute { get; init; }
     public required bool HasOtherRequiredProperties { get; init; }
     public required bool HasEmptyConstructor { get; init; }
     public RecordImmutableArray<ParentTypeDefinition> ParentTypes { get; init; } = new();

--- a/src/Yoyoyopo5.ValueWrapper.Roslyn.Shared/ValueWrapperConstants.cs
+++ b/src/Yoyoyopo5.ValueWrapper.Roslyn.Shared/ValueWrapperConstants.cs
@@ -5,6 +5,8 @@ public static class ValueWrapperConstants
     public const string WRAPPER_ATTRIBUTE_NAME = "Yoyoyopo5.ValueWrapper.WrapperAttribute`1";
     public const string WRAPPER_INTERFACE_NAME = "global::Yoyoyopo5.ValueWrapper.IWrapValue`2";
     public const string JSON_CONVERTER_ATTRIBUTE_TYPE_NAME = "System.Text.Json.Serialization.JsonConverterAttribute";
+    public const string TYPE_CONVERTER_ATTRIBUTE_TYPE_NAME = "System.ComponentModel.TypeConverterAttribute";
     public const string WRAPPER_JSON_CONVERTER_NAME = "global::Yoyoyopo5.ValueWrapper.WrapperJsonConverter`2";
+    public const string WRAPPER_TYPE_CONVERTER_NAME = "global::Yoyoyopo5.ValueWrapper.WrapperTypeConverter`2";
     public const string SCRIBAN_TEMPLATE_FILENAME = "Yoyoyopo5.ValueWrapper.Generator.ValueWrapper.scriban";
 }

--- a/src/Yoyoyopo5.ValueWrapper/WrapperTypeConverter.cs
+++ b/src/Yoyoyopo5.ValueWrapper/WrapperTypeConverter.cs
@@ -1,0 +1,51 @@
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Yoyoyopo5.ValueWrapper;
+
+/// <summary>
+/// Type converter for wrapper types implementing <see cref="IWrapValue{T, TWrapper}"/>.
+/// </summary>
+/// <typeparam name="TWrapper">The wrapper type.</typeparam>
+/// <typeparam name="TWrapped">The wrapped type.</typeparam>
+public class WrapperTypeConverter<TWrapper, TWrapped> : TypeConverter
+    where TWrapper : IWrapValue<TWrapped, TWrapper>
+{
+    private static readonly TypeConverter _wrappedConverter = TypeDescriptor.GetConverter(typeof(TWrapped));
+
+    /// <inheritdoc/>
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+        => sourceType == typeof(TWrapped)
+        || _wrappedConverter.CanConvertFrom(context, sourceType)
+        || base.CanConvertFrom(context, sourceType);
+
+    /// <inheritdoc/>
+    public override bool CanConvertTo(ITypeDescriptorContext? context, [NotNullWhen(true)] Type? destinationType)
+        => destinationType == typeof(TWrapped)
+        || _wrappedConverter.CanConvertTo(context, destinationType)
+        || base.CanConvertTo(context, destinationType);
+
+    /// <inheritdoc/>
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+        => value switch
+        {
+            TWrapped wrappedValue => wrappedValue,
+            _ => (TWrapped?)_wrappedConverter.ConvertFrom(context, culture, value)
+        } switch
+        {
+            TWrapped wrappedValue => TWrapper.Create(wrappedValue),
+            _ => null
+        };
+
+
+    /// <inheritdoc/>
+    public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
+        => value switch
+        {
+            TWrapper wrapper when destinationType == typeof(TWrapped) => wrapper.Value,
+            TWrapper wrapper => _wrappedConverter.ConvertTo(context, culture, wrapper.Value, destinationType),
+            null => null,
+            _ => base.ConvertTo(context, culture, value, destinationType)
+        };
+}

--- a/tests/Yoyoyopo5.ValueWrapper.Generator.Tests/Test_ValueWrapperDefinition.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Generator.Tests/Test_ValueWrapperDefinition.cs
@@ -15,6 +15,7 @@ public class Test_ValueWrapperDefinition
         ToStringOverride = new(),
         HasEmptyConstructor = true,
         HasJsonConverterAttribute = true,
+        HasTypeConverterAttribute = false,
         HasOtherRequiredProperties = false,
         ImplicitOperator = null,
         IsGlobalNamespace = false,

--- a/tests/Yoyoyopo5.ValueWrapper.Generator.Tests/Test_ValueWrapperGenerator_Generation.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Generator.Tests/Test_ValueWrapperGenerator_Generation.cs
@@ -10,9 +10,10 @@ public class Test_ValueWrapperGenerator_Generation
         using System;
         using System.Text.Json;
         using System.Text.Json.Serialization;
+        using System.ComponentModel;
 
         namespace TestNamespace;
-        public class FakeConverter<T> : JsonConverter<T>
+        public class FakeJsonConverter<T> : JsonConverter<T>
         {
             public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
@@ -23,6 +24,8 @@ public class Test_ValueWrapperGenerator_Generation
                 throw new NotImplementedException();
             }
         }
+
+        public class FakeTypeConverter : TypeConverter { }
 
         """;
 
@@ -45,6 +48,7 @@ public class Test_ValueWrapperGenerator_Generation
             namespace TestNamespace;
 
             [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperJsonConverter<AddsAllMembersToEmptyType, global::System.String>))]
+            [global::System.ComponentModel.TypeConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperTypeConverter<AddsAllMembersToEmptyType, global::System.String>))]
             public readonly partial record struct AddsAllMembersToEmptyType
                 : global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.String, AddsAllMembersToEmptyType>
             {
@@ -63,9 +67,11 @@ public class Test_ValueWrapperGenerator_Generation
             Input = """
             using Yoyoyopo5.ValueWrapper;
             using System.Text.Json.Serialization;
+            using System.ComponentModel;
             namespace TestNamespace;
             [Wrapper<string>]
-            [JsonConverter(typeof(FakeConverter<string>))]
+            [JsonConverter(typeof(FakeJsonConverter<string>))]
+            [TypeConverter(typeof(FakeTypeConverter))]
             public readonly partial record struct AddsCreateMethodToFullType
             {
                 public required string Value { get; init; }
@@ -126,6 +132,7 @@ public class Test_ValueWrapperGenerator_Generation
                 public partial class ContainerTwo
                 {
                     [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperJsonConverter<GeneratesNestedWrapperType, global::System.Int32>))]
+                    [global::System.ComponentModel.TypeConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperTypeConverter<GeneratesNestedWrapperType, global::System.Int32>))]
                     private partial class GeneratesNestedWrapperType
                         : global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.Int32, GeneratesNestedWrapperType>
                     {
@@ -156,6 +163,7 @@ public class Test_ValueWrapperGenerator_Generation
             namespace TestNamespace;
             
             [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperJsonConverter<SkipsValuePropertyOnRecordWithPrimaryConstructor, global::System.Double>))]
+            [global::System.ComponentModel.TypeConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperTypeConverter<SkipsValuePropertyOnRecordWithPrimaryConstructor, global::System.Double>))]
             public partial record class SkipsValuePropertyOnRecordWithPrimaryConstructor
                 : global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.Double, SkipsValuePropertyOnRecordWithPrimaryConstructor>
             {
@@ -196,12 +204,12 @@ public class Test_ValueWrapperGenerator_Generation
         },
         new SourceGeneratorTestCase()
         {
-            Name = "SkipsAddingJsonConverterWithNonValueRequiredProps",
+            Name = "SkipsAddingConvertersWithNonValueRequiredProps",
             Input = """
             namespace TestNamespace;
             using Yoyoyopo5.ValueWrapper;
             [Wrapper<string>]
-            public partial record SkipsAddingJsonConverterWithNonValueRequiredProps
+            public partial record SkipsAddingConvertersWithNonValueRequiredProps
             {
                 public required int Amount { get; init; }
             }
@@ -212,24 +220,24 @@ public class Test_ValueWrapperGenerator_Generation
             
             namespace TestNamespace;
             
-            public partial record class SkipsAddingJsonConverterWithNonValueRequiredProps
+            public partial record class SkipsAddingConvertersWithNonValueRequiredProps
             {
                 public required global::System.String Value { get; init; }
-                public static implicit operator global::System.String(SkipsAddingJsonConverterWithNonValueRequiredProps wrapper) => wrapper.Value;
+                public static implicit operator global::System.String(SkipsAddingConvertersWithNonValueRequiredProps wrapper) => wrapper.Value;
                 public override global::System.String ToString() => Value.ToString();
             }
 
             """,
-            ExpectedOutputFilePath = $"TestNamespace_SkipsAddingJsonConverterWithNonValueRequiredProps{EXPECTED_FILE_PATH_SUFFIX}"
+            ExpectedOutputFilePath = $"TestNamespace_SkipsAddingConvertersWithNonValueRequiredProps{EXPECTED_FILE_PATH_SUFFIX}"
         },
         new SourceGeneratorTestCase()
         {
-            Name = "SkipsAddingJsonConverterOnRecordWithNonValuePrimaryConstructorArgs",
+            Name = "SkipsAddingConvertersOnRecordWithNonValuePrimaryConstructorArgs",
             Input = """
             namespace TestNamespace;
             using Yoyoyopo5.ValueWrapper;
             [Wrapper<string>]
-            public partial record SkipsAddingJsonConverterOnRecordWithNonValuePrimaryConstructorArgs(int Amount);
+            public partial record SkipsAddingConvertersOnRecordWithNonValuePrimaryConstructorArgs(int Amount);
             """,
             ExpectedOutput = """
             // <auto-generated/>
@@ -237,28 +245,28 @@ public class Test_ValueWrapperGenerator_Generation
             
             namespace TestNamespace;
             
-            public partial record class SkipsAddingJsonConverterOnRecordWithNonValuePrimaryConstructorArgs
+            public partial record class SkipsAddingConvertersOnRecordWithNonValuePrimaryConstructorArgs
             {
                 public required global::System.String Value { get; init; }
-                public static implicit operator global::System.String(SkipsAddingJsonConverterOnRecordWithNonValuePrimaryConstructorArgs wrapper) => wrapper.Value;
+                public static implicit operator global::System.String(SkipsAddingConvertersOnRecordWithNonValuePrimaryConstructorArgs wrapper) => wrapper.Value;
                 public override global::System.String ToString() => Value.ToString();
             }
 
             """,
-            ExpectedOutputFilePath = $"TestNamespace_SkipsAddingJsonConverterOnRecordWithNonValuePrimaryConstructorArgs{EXPECTED_FILE_PATH_SUFFIX}"
+            ExpectedOutputFilePath = $"TestNamespace_SkipsAddingConvertersOnRecordWithNonValuePrimaryConstructorArgs{EXPECTED_FILE_PATH_SUFFIX}"
         },
         new SourceGeneratorTestCase()
         {
-            Name = "AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod",
+            Name = "AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod",
             Input = """
             namespace TestNamespace;
             using Yoyoyopo5.ValueWrapper;
             [Wrapper<string>]
-            public partial record AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod(int OtherAmount)
+            public partial record AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod(int OtherAmount)
             {
                 public string Value => (Amount + OtherAmount).ToString();
                 public required int Amount { get; init; }
-                public static AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod Create(string amount)
+                public static AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod Create(string amount)
                     => new(0) { Amount = int.Parse(amount) };
             }
 
@@ -269,17 +277,18 @@ public class Test_ValueWrapperGenerator_Generation
             
             namespace TestNamespace;
             
-            [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperJsonConverter<AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod, global::System.String>))]
-            public partial record class AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod
-                : global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.String, AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod>
+            [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperJsonConverter<AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod, global::System.String>))]
+            [global::System.ComponentModel.TypeConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperTypeConverter<AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod, global::System.String>))]
+            public partial record class AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod
+                : global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.String, AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod>
             {
-                public static implicit operator global::System.String(AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod wrapper) => wrapper.Value;
+                public static implicit operator global::System.String(AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod wrapper) => wrapper.Value;
                 public override global::System.String ToString() => Value.ToString();
-                static AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.String, AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod>.Create(global::System.String value) => Create(value);
+                static AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.String, AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod>.Create(global::System.String value) => Create(value);
             }
 
             """,
-            ExpectedOutputFilePath = $"TestNamespace_AddsJsonConverterWithNonValueRequiredPropsAndSuitableStaticCreateMethod{EXPECTED_FILE_PATH_SUFFIX}"
+            ExpectedOutputFilePath = $"TestNamespace_AddsConvertersWithNonValueRequiredPropsAndSuitableStaticCreateMethod{EXPECTED_FILE_PATH_SUFFIX}"
         },
         new SourceGeneratorTestCase()
         {
@@ -298,6 +307,7 @@ public class Test_ValueWrapperGenerator_Generation
             namespace TestNamespace;
             
             [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperJsonConverter<AddMembersToWrappedNullableValueType, global::System.Int32?>))]
+            [global::System.ComponentModel.TypeConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperTypeConverter<AddMembersToWrappedNullableValueType, global::System.Int32?>))]
             public readonly partial record struct AddMembersToWrappedNullableValueType
                 : global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.Int32?, AddMembersToWrappedNullableValueType>
             {
@@ -322,6 +332,39 @@ public class Test_ValueWrapperGenerator_Generation
             """,
             ExpectedOutput = null,
             ExpectedOutputFilePath = null
+        },
+        new SourceGeneratorTestCase()
+        {
+            Name = "AddsConvertersToFullWrapper",
+            Input = """
+            namespace TestNamespace;
+            using Yoyoyopo5.ValueWrapper;
+
+            [Wrapper<int>]
+            public partial class AddsConvertersToFullWrapper
+            {
+                public required int Value { get; init; }
+                public override string ToString() => Value.ToString();
+                public static implicit operator int(AddsConvertersToFullWrapper wrapper) => wrapper.Value;
+                public static AddsConvertersToFullWrapper Create(int value) => new() { Value = value };
+            }
+            """,
+            ExpectedOutput = """
+            // <auto-generated/>
+            #nullable enable
+            
+            namespace TestNamespace;
+            
+            [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperJsonConverter<AddsConvertersToFullWrapper, global::System.Int32>))]
+            [global::System.ComponentModel.TypeConverter(typeof(global::Yoyoyopo5.ValueWrapper.WrapperTypeConverter<AddsConvertersToFullWrapper, global::System.Int32>))]
+            public partial class AddsConvertersToFullWrapper
+                : global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.Int32, AddsConvertersToFullWrapper>
+            {
+                static AddsConvertersToFullWrapper global::Yoyoyopo5.ValueWrapper.IWrapValue<global::System.Int32, AddsConvertersToFullWrapper>.Create(global::System.Int32 value) => Create(value);
+            }
+
+            """,
+            ExpectedOutputFilePath = $"TestNamespace_AddsConvertersToFullWrapper{EXPECTED_FILE_PATH_SUFFIX}"
         }
     ];
     public static TheoryData<TestCaseWrapper<SourceGeneratorTestCase>> TestCases

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/ITestWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/ITestWrapper.cs
@@ -1,0 +1,8 @@
+﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
+
+public interface ITestWrapper<out TWrapped, out TWrapper>
+    where TWrapper : notnull, IWrapValue<TWrapped, TWrapper>
+{
+    static abstract TWrapped TestValue { get; }
+    static abstract TWrapper TestWrapper { get; } 
+}

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_BoolWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_BoolWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<bool>]
-public readonly partial record struct BoolWrapper(bool Value);
-
-public class Test_BoolWrapper : Test_WrapperJsonConverter<BoolWrapper, bool>
+public readonly partial record struct BoolWrapper(bool Value) : ITestWrapper<bool, BoolWrapper>
 {
-    protected override bool TestValue { get; } = false;
-    protected override BoolWrapper TestWrapper { get; } = new(true);
+    public static bool TestValue { get; } = false;
+    public static BoolWrapper TestWrapper { get; } = new(true);
 }
+
+public class Test_BoolWrapperJsonConverter : Test_WrapperJsonConverter<BoolWrapper, bool>;
+public class Test_BoolWrapperTypeConverter : Test_WrapperTypeConverter<BoolWrapper, bool>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_ByteWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_ByteWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<byte>]
-public readonly partial record struct ByteWrapper(byte Value);
-
-public class Test_ByteWrapper : Test_WrapperJsonConverter<ByteWrapper, byte>
+public readonly partial record struct ByteWrapper(byte Value) : ITestWrapper<byte, ByteWrapper>
 {
-    protected override byte TestValue { get; } = 2;
-    protected override ByteWrapper TestWrapper { get; } = new(128);
+    public static byte TestValue { get; } = 2;
+    public static ByteWrapper TestWrapper { get; } = new(128);
 }
+
+public class Test_ByteWrapperJsonConverter : Test_WrapperJsonConverter<ByteWrapper, byte>;
+public class Test_ByteWrapperTypeConverter : Test_WrapperTypeConverter<ByteWrapper, byte>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_CharWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_CharWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<char>]
-public readonly partial record struct CharWrapper(char Value);
-
-public class Test_CharWrapper : Test_WrapperJsonConverter<CharWrapper, char>
+public readonly partial record struct CharWrapper(char Value) : ITestWrapper<char, CharWrapper>
 {
-    protected override char TestValue { get; } = 'a';
-    protected override CharWrapper TestWrapper { get; } = new(' ');
+    public static char TestValue { get; } = 'a';
+    public static CharWrapper TestWrapper { get; } = new(' ');
 }
+
+public class Test_CharWrapperJsonConverter : Test_WrapperJsonConverter<CharWrapper, char>;
+public class Test_CharWrapperTypeConverter : Test_WrapperTypeConverter<CharWrapper, char>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_DateTimeOffsettWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_DateTimeOffsettWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<DateTimeOffset>]
-public readonly partial record struct DateTimeOffsetWrapper(DateTimeOffset Value);
-
-public class Test_DateTimeOffsetWrapper : Test_WrapperJsonConverter<DateTimeOffsetWrapper, DateTimeOffset>
+public readonly partial record struct DateTimeOffsetWrapper(DateTimeOffset Value) : ITestWrapper<DateTimeOffset, DateTimeOffsetWrapper>
 {
-    protected override DateTimeOffset TestValue { get; } = DateTimeOffset.MinValue + TimeSpan.FromDays(23);
-    protected override DateTimeOffsetWrapper TestWrapper { get; } = new(DateTimeOffset.MaxValue);
+    public static DateTimeOffset TestValue { get; } = DateTimeOffset.MinValue + TimeSpan.FromDays(23);
+    public static DateTimeOffsetWrapper TestWrapper { get; } = new(DateTimeOffset.MinValue + TimeSpan.FromDays(20));
 }
+
+public class Test_DateTimeOffsetWrapperJsonConverter : Test_WrapperJsonConverter<DateTimeOffsetWrapper, DateTimeOffset>;
+public class Test_DateTimeOffsetWrapperTypeConverter : Test_WrapperTypeConverter<DateTimeOffsetWrapper, DateTimeOffset>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_DateTimeWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_DateTimeWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<DateTime>]
-public readonly partial record struct DateTimeWrapper(DateTime Value);
-
-public class Test_DateTimeWrapper : Test_WrapperJsonConverter<DateTimeWrapper, DateTime>
+public readonly partial record struct DateTimeWrapper(DateTime Value) : ITestWrapper<DateTime, DateTimeWrapper>
 {
-    protected override DateTime TestValue { get; } = DateTime.MinValue + TimeSpan.FromDays(2946);
-    protected override DateTimeWrapper TestWrapper { get; } = new(DateTime.MaxValue);
+    public static DateTime TestValue { get; } = DateTime.MinValue + TimeSpan.FromDays(2946);
+    public static DateTimeWrapper TestWrapper { get; } = new(DateTime.MinValue + TimeSpan.FromDays(218));
 }
+
+public class Test_DateTimeWrapperJsonConverter : Test_WrapperJsonConverter<DateTimeWrapper, DateTime>;
+public class Test_DateTimeWrapperTypeConverter : Test_WrapperTypeConverter<DateTimeWrapper, DateTime>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_DecimalWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_DecimalWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<decimal>]
-public readonly partial record struct DecimalWrapper(decimal Value);
-
-public class Test_DecimalWrapper : Test_WrapperJsonConverter<DecimalWrapper, decimal>
+public readonly partial record struct DecimalWrapper(decimal Value) : ITestWrapper<decimal, DecimalWrapper>
 {
-    protected override decimal TestValue { get; } = 123.2738m;
-    protected override DecimalWrapper TestWrapper { get; } = new(947.002783m);
+    public static decimal TestValue { get; } = 123.2738m;
+    public static DecimalWrapper TestWrapper { get; } = new(947.002783m);
 }
+
+public class Test_DecimalWrapperJsonConverter : Test_WrapperJsonConverter<DecimalWrapper, decimal>;
+public class Test_DecimalWrapperTypeConverter : Test_WrapperTypeConverter<DecimalWrapper, decimal>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_DoubleWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_DoubleWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<double>]
-public readonly partial record struct DoubleWrapper(double Value);
-
-public class Test_DoubleWrapper : Test_WrapperJsonConverter<DoubleWrapper, double>
+public readonly partial record struct DoubleWrapper(double Value) : ITestWrapper<double, DoubleWrapper>
 {
-    protected override double TestValue { get; } = 1.23;
-    protected override DoubleWrapper TestWrapper { get; } = new(2.4782);
+    public static double TestValue { get; } = 1.23;
+    public static DoubleWrapper TestWrapper { get; } = new(2.4782);
 }
+
+public class Test_DoubleWrapperJsonConverter : Test_WrapperJsonConverter<DoubleWrapper, double>;
+public class Test_DoubleWrapperTypeConverter : Test_WrapperTypeConverter<DoubleWrapper, double>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_FloatWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_FloatWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<float>]
-public readonly partial record struct FloatWrapper(float Value);
-
-public class Test_FloatWrapper : Test_WrapperJsonConverter<FloatWrapper, float>
+public readonly partial record struct FloatWrapper(float Value) : ITestWrapper<float, FloatWrapper>
 {
-    protected override float TestValue { get; } = 1.0f;
-    protected override FloatWrapper TestWrapper { get; } = new(283.2f);
+    public static float TestValue { get; } = 1.0f;
+    public static FloatWrapper TestWrapper { get; } = new(283.2f);
 }
+
+public class Test_FloatWrapperJsonConverter : Test_WrapperJsonConverter<FloatWrapper, float>;
+public class Test_FloatWrapperTypeConverter : Test_WrapperTypeConverter<FloatWrapper, float>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_GuidWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_GuidWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<Guid>]
-public readonly partial record struct GuidWrapper(Guid Value);
-
-public class Test_GuidWrapper : Test_WrapperJsonConverter<GuidWrapper, Guid>
+public readonly partial record struct GuidWrapper(Guid Value) : ITestWrapper<Guid, GuidWrapper>
 {
-    protected override Guid TestValue { get; } = Guid.Parse("317ad520-c87f-4577-b0aa-17245946ebe9");
-    protected override GuidWrapper TestWrapper { get; } = new(Guid.Parse("d97682a1-9df5-4299-af84-229dda964983"));
+    public static Guid TestValue { get; } = Guid.Parse("317ad520-c87f-4577-b0aa-17245946ebe9");
+    public static GuidWrapper TestWrapper { get; } = new(Guid.Parse("d97682a1-9df5-4299-af84-229dda964983"));
 }
+
+public class Test_GuidWrapperJsonConverter : Test_WrapperJsonConverter<GuidWrapper, Guid>;
+public class Test_GuidWrapperTypeConverter : Test_WrapperTypeConverter<GuidWrapper, Guid>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_IntWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_IntWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<int>]
-public readonly partial record struct IntWrapper(int Value);
-
-public class Test_IntWrapper : Test_WrapperJsonConverter<IntWrapper, int>
+public readonly partial record struct IntWrapper(int Value) : ITestWrapper<int, IntWrapper>
 {
-    protected override int TestValue { get; } = -2;
-    protected override IntWrapper TestWrapper { get; } = new(500);
+    public static int TestValue { get; } = -2;
+    public static IntWrapper TestWrapper { get; } = new(500);
 }
+
+public class Test_IntWrapperJsonConverter : Test_WrapperJsonConverter<IntWrapper, int>;
+public class Test_IntWrapperTypeConverter : Test_WrapperTypeConverter<IntWrapper, int>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_JsonEncodedTextWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_JsonEncodedTextWrapper.cs
@@ -4,14 +4,11 @@ using System.Text.Json.Serialization;
 namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<JsonEncodedText>]
-public readonly partial record struct JsonEncodedTextWrapper(JsonEncodedText Value);
-
-public class Test_JsonEncodedTextWrapper : Test_WrapperJsonConverter<JsonEncodedTextWrapper, JsonEncodedText>
+public readonly partial record struct JsonEncodedTextWrapper(JsonEncodedText Value) : ITestWrapper<JsonEncodedText, JsonEncodedTextWrapper>
 {
-    protected override JsonEncodedText TestValue { get; } = JsonEncodedText.Encode("{ \"property\": \"value\" }");
-    protected override JsonEncodedTextWrapper TestWrapper { get; } = new(JsonEncodedText.Encode("null"));
+    public static JsonEncodedText TestValue { get; } = JsonEncodedText.Encode("{ \"property\": \"value\" }");
+    public static JsonEncodedTextWrapper TestWrapper { get; } = new(JsonEncodedText.Encode("null"));
 }
-
 public class JsonEncodedTextConverter : JsonConverter<JsonEncodedText>
 {
     public override JsonEncodedText Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -20,3 +17,7 @@ public class JsonEncodedTextConverter : JsonConverter<JsonEncodedText>
     public override void Write(Utf8JsonWriter writer, JsonEncodedText value, JsonSerializerOptions options)
         => writer.WriteStringValue(value);
 }
+
+public class Test_JsonEncodedTextWrapperJsonConverter : Test_WrapperJsonConverter<JsonEncodedTextWrapper, JsonEncodedText>;
+// public class Test_JsonEncodedTextWrapperTypeConverter : Test_WrapperTypeConverter<JsonEncodedTextWrapper, JsonEncodedText>;
+// JsonEncodedText TypeConverter does not support converting from string.

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_LongWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_LongWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<long>]
-public readonly partial record struct LongWrapper(long Value);
-
-public class Test_LongWrapper : Test_WrapperJsonConverter<LongWrapper, long>
+public readonly partial record struct LongWrapper(long Value) : ITestWrapper<long, LongWrapper>
 {
-    protected override long TestValue { get; } = -2;
-    protected override LongWrapper TestWrapper { get; } = new(500);
+    public static long TestValue { get; } = -2;
+    public static LongWrapper TestWrapper { get; } = new(500);
 }
+
+public class Test_LongWrapperJsonConverter : Test_WrapperJsonConverter<LongWrapper, long>;
+public class Test_LongWrapperTypeConverter : Test_WrapperTypeConverter<LongWrapper, long>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_NIntWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_NIntWrapper.cs
@@ -4,14 +4,11 @@ using System.Text.Json.Serialization;
 namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<nint>]
-public readonly partial record struct NIntWrapper(nint Value);
-
-public class Test_NIntWrapper : Test_WrapperJsonConverter<NIntWrapper, nint>
+public readonly partial record struct NIntWrapper(nint Value) : ITestWrapper<nint, NIntWrapper>
 {
-    protected override nint TestValue { get; } = -2;
-    protected override NIntWrapper TestWrapper { get; } = new(500);
+    public static nint TestValue { get; } = -2;
+    public static NIntWrapper TestWrapper { get; } = new(500);
 }
-
 public class NintConverter : JsonConverter<nint>
 {
     public override nint Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -20,3 +17,8 @@ public class NintConverter : JsonConverter<nint>
     public override void Write(Utf8JsonWriter writer, nint value, JsonSerializerOptions options)
         => writer.WriteNumberValue(value);
 }
+
+public class Test_NIntWrapperJsonConverter : Test_WrapperJsonConverter<NIntWrapper, nint>;
+// public class Test_NIntWrapperTypeConverter : Test_WrapperTypeConverter<NIntWrapper, nint>;
+// nint TypeConverter does not support converting from string.
+

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_NUIntWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_NUIntWrapper.cs
@@ -4,14 +4,11 @@ using System.Text.Json.Serialization;
 namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<nuint>]
-public readonly partial record struct NUIntWrapper(nuint Value);
-
-public class Test_NUIntWrapper : Test_WrapperJsonConverter<NUIntWrapper, nuint>
+public readonly partial record struct NUIntWrapper(nuint Value) : ITestWrapper<nuint, NUIntWrapper>
 {
-    protected override nuint TestValue { get; } = 287;
-    protected override NUIntWrapper TestWrapper { get; } = new(500);
+    public static nuint TestValue { get; } = 287;
+    public static NUIntWrapper TestWrapper { get; } = new(500);
 }
-
 public class NUintConverter : JsonConverter<nuint>
 {
     public override nuint Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -20,3 +17,7 @@ public class NUintConverter : JsonConverter<nuint>
     public override void Write(Utf8JsonWriter writer, nuint value, JsonSerializerOptions options)
         => writer.WriteNumberValue(value);
 }
+
+public class Test_NUIntWrapperJsonConverter : Test_WrapperJsonConverter<NUIntWrapper, nuint>;
+// public class Test_NUIntWrapperTypeConverter : Test_WrapperTypeConverter<NUIntWrapper, nuint>;
+// nuint TypeConverter does not support converting from string.

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_RecordWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_RecordWrapper.cs
@@ -1,18 +1,54 @@
-﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
 
+namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
+
+[TypeConverter(typeof(TestRecordTypeConverter))]
 public record TestRecord(string Name, int Amount);
 
-[Wrapper<TestRecord>]
-public partial class TestRecordWrapper;
-
-public class Test_RecordWrapper : Test_WrapperJsonConverter<TestRecordWrapper, TestRecord>
+public class TestRecordTypeConverter : TypeConverter
 {
-    protected override TestRecord? TestValue { get; } = new("wallace", 23);
-    protected override TestRecordWrapper? TestWrapper { get; } = new() { Value = new("walter", -2) };
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+        => sourceType == typeof(string) 
+        || base.CanConvertFrom(context, sourceType);
+
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+        => value switch
+        {
+            string stringValue => JsonSerializer.Deserialize<TestRecord>(stringValue),
+            _ => base.ConvertFrom(context, culture, value)
+        };
+
+    public override bool CanConvertTo(ITypeDescriptorContext? context, [NotNullWhen(true)] Type? destinationType)
+        => destinationType == typeof(string)
+        || base.CanConvertTo(context, destinationType);
+
+    public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
+    {
+        TestRecord? tr = (TestRecord?)value;
+        if (destinationType == typeof(string))
+            return JsonSerializer.Serialize(tr);
+        return base.ConvertTo(context, culture, value, destinationType);
+    }
 }
 
-public class Test_NullRecordWrapper : Test_WrapperJsonConverter<TestRecordWrapper, TestRecord>
+[Wrapper<TestRecord>]
+public partial class TestRecordWrapper : ITestWrapper<TestRecord, TestRecordWrapper>
 {
-    protected override TestRecord? TestValue { get; } = null;
-    protected override TestRecordWrapper? TestWrapper { get; } = null;
+    public static TestRecord TestValue => new("wallace", 23);
+    public static TestRecordWrapper TestWrapper => new() { Value = new("walter", -2) };
+}
+
+public class Test_RecordWrapperJsonConverter : Test_WrapperJsonConverter<TestRecordWrapper, TestRecord>;
+public class Test_NullRecordWrapperJsonConverter : Test_WrapperJsonConverter<TestRecordWrapper, TestRecord>
+{
+    protected override TestRecord TestValue { get; } = null!;
+    protected override TestRecordWrapper TestWrapper { get; } = null!;
+}
+public class Test_RecordWrapperTypeConverter : Test_WrapperTypeConverter<TestRecordWrapper, TestRecord>
+{
+    protected override string? TestValueToString(TestRecord value)
+        => JsonSerializer.Serialize(value);
 }

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_SByteWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_SByteWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<sbyte>]
-public readonly partial record struct SByteWrapper(sbyte Value);
-
-public class Test_SByteWrapper : Test_WrapperJsonConverter<SByteWrapper, sbyte>
+public readonly partial record struct SByteWrapper(sbyte Value) : ITestWrapper<sbyte, SByteWrapper>
 {
-    protected override sbyte TestValue { get; } = -2;
-    protected override SByteWrapper TestWrapper { get; } = new(8);
+    public static sbyte TestValue => 16;
+    public static SByteWrapper TestWrapper => new(-32);
 }
+
+public class Test_SByteWrapperJsonConverter : Test_WrapperJsonConverter<SByteWrapper, sbyte>;
+public class Test_SByteWrapperTypeConverter : Test_WrapperTypeConverter<SByteWrapper, sbyte>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_ShortWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_ShortWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<short>]
-public readonly partial record struct ShortWrapper(short Value);
-
-public class Test_ShortWrapper : Test_WrapperJsonConverter<ShortWrapper, short>
+public readonly partial record struct ShortWrapper(short Value) : ITestWrapper<short, ShortWrapper>
 {
-    protected override short TestValue { get; } = -2;
-    protected override ShortWrapper TestWrapper { get; } = new(500);
+    public static short TestValue => -12;
+    public static ShortWrapper TestWrapper => new(64);
 }
+
+public class Test_ShortWrapperJsonConverter : Test_WrapperJsonConverter<ShortWrapper, short>;
+public class Test_ShortWrapperTypeConverter : Test_WrapperTypeConverter<ShortWrapper, short>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_StringWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_StringWrapper.cs
@@ -1,16 +1,16 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<string>]
-public readonly partial record struct StringWrapper(string Value);
-
-public class Test_StringWrapper : Test_WrapperJsonConverter<StringWrapper, string>
+public readonly partial record struct StringWrapper(string Value) : ITestWrapper<string, StringWrapper>
 {
-    protected override string? TestValue { get; } = "yoyo7tiger";
-    protected override StringWrapper TestWrapper { get; } = new("yopobot lives");
+    public static string TestValue => "yoyo7tiger";
+    public static StringWrapper TestWrapper => new("yopobot lives");
 }
 
-public class Test_NullStringWrapper : Test_WrapperJsonConverter<StringWrapper, string>
+public class Test_StringWrapperJsonConverter : Test_WrapperJsonConverter<StringWrapper, string>;
+public class Test_NullStringWrapperJsonConverter : Test_WrapperJsonConverter<StringWrapper, string>
 {
-    protected override string? TestValue { get; } = null;
+    protected override string TestValue { get; } = null!;
     protected override StringWrapper TestWrapper { get; } = default;
 }
+public class Test_StringWrapperTypeConverter : Test_WrapperTypeConverter<StringWrapper, string>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_UIntWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_UIntWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<uint>]
-public readonly partial record struct UIntWrapper(uint Value);
-
-public class Test_UIntWrapper : Test_WrapperJsonConverter<UIntWrapper, uint>
+public readonly partial record struct UIntWrapper(uint Value) : ITestWrapper<uint, UIntWrapper>
 {
-    protected override uint TestValue { get; } = 1000;
-    protected override UIntWrapper TestWrapper { get; } = new(500);
+    public static uint TestValue => 127;
+    public static UIntWrapper TestWrapper => new(124907);
 }
+
+public class Test_UIntWrapperJsonConverter : Test_WrapperJsonConverter<UIntWrapper, uint>;
+public class Test_UIntWrapperTypeConverter : Test_WrapperTypeConverter<UIntWrapper, uint>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_ULongWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_ULongWrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<ulong>]
-public readonly partial record struct ULongWrapper(ulong Value);
-
-public class Test_ULongWrapper : Test_WrapperJsonConverter<ULongWrapper, ulong>
+public readonly partial record struct ULongWrapper(ulong Value) : ITestWrapper<ulong, ULongWrapper>
 {
-    protected override ulong TestValue { get; } = 29371654;
-    protected override ULongWrapper TestWrapper { get; } = new(500);
+    public static ulong TestValue => 1287;
+    public static ULongWrapper TestWrapper => new(123787);
 }
+
+public class Test_ULongWrapperJsonConverter : Test_WrapperJsonConverter<ULongWrapper, ulong>;
+public class Test_ULongWrapperTypeConverter : Test_WrapperTypeConverter<ULongWrapper, ulong>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_UShortWrapper.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_UShortWrapper.cs
@@ -1,10 +1,12 @@
 ﻿namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 
 [Wrapper<ushort>]
-public readonly partial record struct UShortWrapper(ushort Value);
-
-public class Test_UShortWrapper : Test_WrapperJsonConverter<UShortWrapper, ushort>
+public readonly partial record struct UShortWrapper(ushort Value) 
+    : ITestWrapper<ushort, UShortWrapper>
 {
-    protected override ushort TestValue { get; } = 127;
-    protected override UShortWrapper TestWrapper { get; } = new(500);
+    public static UShortWrapper TestWrapper { get; } = new UShortWrapper(500);
+    public static ushort TestValue { get; } = 127;
 }
+
+public sealed class Test_UShortWrapperJsonConverter : Test_WrapperJsonConverter<UShortWrapper, ushort>;
+public sealed class Test_UShortWrapperTypeConverter : Test_WrapperTypeConverter<UShortWrapper, ushort>;

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_WrapperJsonConverter.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_WrapperJsonConverter.cs
@@ -2,10 +2,10 @@
 
 namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
 public abstract class Test_WrapperJsonConverter<TWrapper, TWrapped>
-    where TWrapper : IWrapValue<TWrapped, TWrapper>
+    where TWrapper : IWrapValue<TWrapped, TWrapper>, ITestWrapper<TWrapped, TWrapper>
 {
-    protected abstract TWrapped? TestValue { get; }
-    protected abstract TWrapper? TestWrapper { get; }
+    protected virtual TWrapped TestValue { get; } = TWrapper.TestValue;
+    protected virtual TWrapper TestWrapper { get; } = TWrapper.TestWrapper;
 
     private readonly static JsonSerializerOptions options = new()
     {
@@ -28,7 +28,7 @@ public abstract class Test_WrapperJsonConverter<TWrapper, TWrapped>
     {
         string json = JsonSerializer.Serialize(TestWrapper is not null ? TestWrapper.Value : default, options);
 
-        string result = JsonSerializer.Serialize(TestWrapper);
+        string result = JsonSerializer.Serialize(TestWrapper!);
 
         Assert.Equal(json, result);
     }

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_WrapperTypeConverter.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_WrapperTypeConverter.cs
@@ -1,0 +1,59 @@
+﻿using System.ComponentModel;
+
+namespace Yoyoyopo5.ValueWrapper.Tests.Unit;
+
+public abstract class Test_WrapperTypeConverter<TWrapper, TWrapped>
+    where TWrapper : IWrapValue<TWrapped, TWrapper>, ITestWrapper<TWrapped, TWrapper>
+{
+    protected virtual TWrapped TestValue { get; } = TWrapper.TestValue;
+    protected virtual TWrapper TestWrapper { get; } = TWrapper.TestWrapper;
+    protected virtual string? TestValueToString(TWrapped value) => value?.ToString();
+
+    private readonly TypeConverter _converter = TypeDescriptor.GetConverter(typeof(TWrapper));
+
+    [Fact]
+    public void TypeConverter_RoundTripString_ReturnsWrapperWithSameValue()
+    {
+        if (_converter.ConvertToInvariantString(TestWrapper) is not string s)
+        {
+            Assert.Null(TestWrapper);
+            return;
+        }
+        
+        object? wrapper = _converter.ConvertFromInvariantString(s);
+        Assert.IsType<TWrapper>(wrapper);
+        Assert.Equal(TestWrapper.Value, ((TWrapper)wrapper).Value);
+    }
+
+    [Fact]
+    public void TypeConverter_ConvertsFromWrappedType_ReturnsWrapper()
+    {
+        object? wrapper = TestValue switch
+        {
+            TWrapped value => _converter.ConvertFrom(value),
+            _ => null
+        };
+        Assert.IsType<TWrapper>(wrapper);
+        Assert.Equal(TestValue, ((TWrapper)wrapper).Value);
+    }
+
+    [Fact]
+    public void TypeConverter_ConvertsFromString_ReturnsWrapper()
+    {
+        object? wrapper = TestValueToString(TestValue) switch
+        {
+            string stringValue => _converter.ConvertFrom(stringValue),
+            _ => null
+        };
+        Assert.IsType<TWrapper>(wrapper);
+        Assert.Equal(TestValue, ((TWrapper)wrapper).Value);
+    }
+
+    [Fact]
+    public void TypeConverter_ConvertsToWrappedType_ReturnsValue()
+    {
+        object? value = _converter.ConvertTo(TestWrapper, typeof(TWrapped));
+        Assert.IsType<TWrapped>(value);
+        Assert.Equal(TestWrapper.Value, (TWrapped)value);
+    }
+}


### PR DESCRIPTION
### What's New
Add a TypeConverter for wrapper types.

This allows transparent usage of wrapper types in Microsoft.Extensions.Configuration.Binder and more.

Adds the `WrapperTypeConverter` class, updates the generator template to include the `[TypeConverter]` attribute on wrapped classes, adds `TypeConverter` unit tests and benchmarks.

### Breaking Changes
None

### Tests
| Test Project | Result | Notes |
| --- | --- | ---|
| Analyzer.Tests | ✅ Passed | 9 of 9 passed |
| Generator.Tests | ✅ Passed | 18 of 18 passed |
| Tests.Unit | ✅ Passed | 141 of 141 passed |

Package was also tested manually with the Microsoft.Extensions.Configuration.Binder and converted a primitive JSON value into the wrapper successfully.

### Limitations
The Binder does not use the `TypeConverter` when dealing with objects, so conversion is not as seamless as with the built-in types. Workarounds include creating the full wrapper object in JSON:
```json
{
  "Value": { }
}
```
Or binding the wrapped type instead and creating the wrapper type manually:
```cs
new Wrapper(configSection.Get<Wrapped>());
```