### PR TITLE
Add support for JSON serialization of Dictionaries with Wrapper key types

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,13 @@ Non-built-in wrapped types incur a penalty.
 | WrapperRoundTripJson   | 136.1 ns | 2.08 ns | 1.95 ns |  1.00 |    0.02 | 0.0043 |      72 B |        1.00 |
 | PrimitiveRoundTripJson | 136.3 ns | 1.49 ns | 1.32 ns |  1.00 |    0.01 | 0.0043 |      72 B |        1.00 |
 
+### System.Text.Json Round-Trip Dictionary with Wrapper Keys
+
+| Method                            | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
+|---------------------------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
+| StringKeyDictionaryRoundTripJson  | 271.0 ns | 2.17 ns | 1.92 ns |  1.00 | 0.0200 |     336 B |        1.00 |
+| WrapperKeyDictionaryRoundTripJson | 277.7 ns | 3.20 ns | 2.99 ns |  1.02 | 0.0219 |     368 B |        1.10 |
+
 ### TypeConverter Round-Trip (to/from `string`)
 
 #### Wrapped `struct`

--- a/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/Json/DictionaryKeyJsonBenchmarks.cs
+++ b/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/Json/DictionaryKeyJsonBenchmarks.cs
@@ -1,0 +1,32 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.Text.Json;
+
+namespace Yoyoyopo5.ValueWrapper.Benchmarks.Json;
+
+[MemoryDiagnoser]
+public class DictionaryKeyJsonBenchmarks
+{
+    private readonly Dictionary<ColorName, string> _wrapperDict = new()
+    {
+        [new ColorName("blue")] = "value"
+    };
+
+    private readonly Dictionary<string, string> _stringDict = new()
+    {
+        ["blue"] = "value"
+    };
+
+    [Benchmark(Baseline = true)]
+    public void StringKeyDictionaryRoundTripJson()
+    {
+        string json = JsonSerializer.Serialize(_stringDict);
+        JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+    }
+
+    [Benchmark]
+    public void WrapperKeyDictionaryRoundTripJson()
+    {
+        string json = JsonSerializer.Serialize(_wrapperDict);
+        JsonSerializer.Deserialize<Dictionary<ColorName, string>>(json);
+    }
+}

--- a/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/Program.cs
+++ b/benchmarks/Yoyoyopo5.ValueWrapper.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using BenchmarkDotNet.Running;
+using System.ComponentModel;
 using Yoyoyopo5.ValueWrapper.Benchmarks;
 using Yoyoyopo5.ValueWrapper.Benchmarks.Create;
 using Yoyoyopo5.ValueWrapper.Benchmarks.Json;
@@ -8,4 +9,5 @@ using Yoyoyopo5.ValueWrapper.Benchmarks.TypeConv;
 //JsonBenchmarks<ColorName, string>.Run();
 //CreateBenchmarks<ColorName, string>.Run();
 //ToStringBenchmarks<ColorName, string>.Run();
-TypeConverterBenchmarks<ColorName, string>.Run();
+//TypeConverterBenchmarks<ColorName, string>.Run();
+BenchmarkRunner.Run<DictionaryKeyJsonBenchmarks>();

--- a/src/Yoyoyopo5.ValueWrapper/WrapperJsonConverter.cs
+++ b/src/Yoyoyopo5.ValueWrapper/WrapperJsonConverter.cs
@@ -22,8 +22,9 @@ public class WrapperJsonConverter<TWrapper, TWrapped> : JsonConverter<TWrapper>
         if (typeof(TWrapped) == typeof(string))
         {
             string? propertyName = reader.GetString();
-            if (propertyName is not null)
-                return TWrapper.Create(AsWrapped(ref propertyName));
+            return propertyName is null 
+                ? default! // I don't think this can actually happen since JSON property names can't be null.
+                : TWrapper.Create(AsWrapped(ref propertyName));
         }
 
         JsonConverter<TWrapped> converter = (JsonConverter<TWrapped>)options.GetConverter(typeof(TWrapped));

--- a/src/Yoyoyopo5.ValueWrapper/WrapperJsonConverter.cs
+++ b/src/Yoyoyopo5.ValueWrapper/WrapperJsonConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -14,6 +15,21 @@ public class WrapperJsonConverter<TWrapper, TWrapped> : JsonConverter<TWrapper>
         => Unsafe.As<T, TWrapped>(ref value);
     private static T AsWrapped<T>(ref TWrapped value)
         => Unsafe.As<TWrapped, T>(ref value);
+
+    /// <inheritdoc/>
+    public override TWrapper ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (typeof(TWrapped) == typeof(string))
+        {
+            string? propertyName = reader.GetString();
+            if (propertyName is not null)
+                return TWrapper.Create(AsWrapped(ref propertyName));
+        }
+
+        JsonConverter<TWrapped> converter = (JsonConverter<TWrapped>)options.GetConverter(typeof(TWrapped));
+        return TWrapper.Create(converter.ReadAsPropertyName(ref reader, typeof(TWrapped), options));
+    }
+
     /// <inheritdoc/>
     public override TWrapper? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -133,6 +149,21 @@ public class WrapperJsonConverter<TWrapper, TWrapped> : JsonConverter<TWrapper>
             _ => default,
         };
     }
+
+    /// <inheritdoc/>
+    public override void WriteAsPropertyName(Utf8JsonWriter writer, [DisallowNull] TWrapper value, JsonSerializerOptions options)
+    {
+        TWrapped wrappedValue = value.Value ?? throw new NotSupportedException($"A {typeof(TWrapper).FullName} with a null Value cannot be serialized as a dictionary key.");
+        if (typeof(TWrapped) == typeof(string))
+        {
+            writer.WritePropertyName(AsWrapped<string>(ref wrappedValue));
+            return;
+        }
+
+        JsonConverter<TWrapped> wrappedConverter = (JsonConverter<TWrapped>)options.GetConverter(typeof(TWrapped));
+        wrappedConverter.WriteAsPropertyName(writer, wrappedValue, options);
+    }
+
     /// <inheritdoc/>
     public override void Write(Utf8JsonWriter writer, TWrapper value, JsonSerializerOptions options)
     {

--- a/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_WrapperJsonConverter.cs
+++ b/tests/Yoyoyopo5.ValueWrapper.Tests.Unit/Test_WrapperJsonConverter.cs
@@ -42,4 +42,22 @@ public abstract class Test_WrapperJsonConverter<TWrapper, TWrapped>
 
         Assert.Equal(TestWrapper is not null ? TestWrapper.Value : default, result is not null ? result.Value : default);
     }
+    
+    [Fact]
+    public void RoundTrip_DictionaryWithWrapperKeysAndValues_PreservesKeysAndValues()
+    {
+        Dictionary<WrapperKey, TWrapper> dictionary = new()
+        {
+            [new WrapperKey("test_key")] = TestWrapper
+        };
+
+        string json = JsonSerializer.Serialize(dictionary);
+        Dictionary<WrapperKey, TWrapper>? result = JsonSerializer.Deserialize<Dictionary<WrapperKey, TWrapper>>(json);
+
+        Assert.NotNull(result);
+        Assert.Equivalent(dictionary, result);
+    }
 }
+
+[Wrapper<string>]
+public readonly partial record struct WrapperKey(string Value);


### PR DESCRIPTION
### What's New

- Add support for System.Text.Json.JsonSerializer serialize and deserialize methods on dictionary types that have wrapper type keys. Previously, this threw a `NotSupportedException`.
- Wrapper type keys with non-string types are passed through to their respective JsonConverter `WriteAsPropertyName` and `ReadAsPropertyName` methods.
- Resolves Issue #7 

### Breaking Changes

- None

### Tests

| Test Project | Results | Notes |
| --- | --- | --- |
| Analyzer.Tests | ✅ Passed | 9 of 9 tests passed |
| Generator.Tests | ✅ Passed | 20 of 20 tests passed |
| Tests.Unit | ✅ Passed | 164 of 164 tests passed |